### PR TITLE
⚡️ Convert bufkit service to async

### DIFF
--- a/src/iemws/services/nws/bufkit.py
+++ b/src/iemws/services/nws/bufkit.py
@@ -35,6 +35,7 @@ The service will return a HTTP status code of 422 for requests that are
 slightly not what we expect.
 """
 
+import asyncio
 import json
 import os
 from datetime import datetime, timedelta, timezone
@@ -203,7 +204,7 @@ def do_gr(ctx: dict):
     return res
 
 
-def handler(ctx: dict):
+async def handler(ctx: dict):
     """Handle the request, return dict"""
     begin = utc()
     model = ctx["model"].upper()
@@ -255,42 +256,45 @@ def handler(ctx: dict):
     sio = StringIO()
     sz = 0
     url = ""
-    for station, runtime in [(x, y) for x in stations for y in runtimes]:
-        runtime = runtime.replace(tzinfo=timezone.utc)
-        prefix = model.lower()
-        if model in [
-            "NAM",
-        ] and runtime.hour in [6, 18]:
-            prefix = "namm"
-        if model == "GFS":
-            prefix = "gfs3"
-        station_path = quote(station.lower(), safe="")
-        ymdh = runtime.strftime("%Y/%m/%d/bufkit/%H")
-        url = f"{BASEURL}/{ymdh}/{model.lower()}/{prefix}_{station_path}.buf"
-        try:
-            # Tightened up to attempt to prevent service stacking
-            resp = httpx.get(url, timeout=10)
-        except Exception as exp:
-            LOG.warning("URL %s download failed with %s", url, exp)
-            raise HTTPException(
-                503,
-                detail="mtarchive backend failed, try later please.",
-            ) from exp
-        if resp.status_code == 200:
-            sz = sio.write(resp.text)
-            row = LOCS[(LOCS["model"] == model) & (LOCS["sid"] == station)]
-            if isinstance(row, pd.DataFrame):
-                row = row.iloc[0]
-            lat = float(row["lat"])
-            lon = float(row["lon"])
-            break
+    async with httpx.AsyncClient(timeout=10) as client:
+        for station, runtime in [(x, y) for x in stations for y in runtimes]:
+            runtime = runtime.replace(tzinfo=timezone.utc)
+            prefix = model.lower()
+            if model in [
+                "NAM",
+            ] and runtime.hour in [6, 18]:
+                prefix = "namm"
+            if model == "GFS":
+                prefix = "gfs3"
+            station_path = quote(station.lower(), safe="")
+            ymdh = runtime.strftime("%Y/%m/%d/bufkit/%H")
+            url = (
+                f"{BASEURL}/{ymdh}/{model.lower()}/{prefix}_{station_path}.buf"
+            )
+            try:
+                # Tightened up to attempt to prevent service stacking
+                resp = await client.get(url)
+            except Exception as exp:
+                LOG.warning("URL %s download failed with %s", url, exp)
+                raise HTTPException(
+                    503,
+                    detail="mtarchive backend failed, try later please.",
+                ) from exp
+            if resp.status_code == 200:
+                sz = sio.write(resp.text)
+                row = LOCS[(LOCS["model"] == model) & (LOCS["sid"] == station)]
+                if isinstance(row, pd.DataFrame):
+                    row = row.iloc[0]
+                lat = float(row["lat"])
+                lon = float(row["lon"])
+                break
     if sz == 0:
         raise HTTPException(422, detail="Could not find any profile.")
     if ctx["fmt"] == "txt":
         return sio.getvalue()
 
     try:
-        sndf, stndf = read_bufkit(sio)
+        sndf, stndf = await asyncio.to_thread(read_bufkit, sio)
     except Exception as exp:
         LOG.warning("URL %s failed bufkit reader with %s", url, exp)
         raise HTTPException(
@@ -337,7 +341,7 @@ def handler(ctx: dict):
 
 
 @router.get("/nws/bufkit.{fmt}", description=__doc__, tags=["nws"])
-def service(
+async def service(
     fmt: SupportedFormatsNoGeoJSON,
     lon: float = Query(None, ge=-180, le=180, description="degrees E"),
     lat: float = Query(None, ge=-90, le=90, description="degrees N"),
@@ -365,7 +369,7 @@ def service(
         "fall": fall,
         "gr": gr,
     }
-    return Response(handler(ctx), media_type=MEDIATYPES[fmt])
+    return Response(await handler(ctx), media_type=MEDIATYPES[fmt])
 
 
 service.__doc__ = __doc__

--- a/src/iemws/services/nws/bufkit.py
+++ b/src/iemws/services/nws/bufkit.py
@@ -40,6 +40,7 @@ import json
 import os
 from datetime import datetime, timedelta, timezone
 from io import StringIO
+from typing import Annotated
 from urllib.parse import quote
 
 import httpx
@@ -256,6 +257,7 @@ async def handler(ctx: dict):
     sio = StringIO()
     sz = 0
     url = ""
+    last_request_error = None
     async with httpx.AsyncClient(timeout=10) as client:
         for station, runtime in [(x, y) for x in stations for y in runtimes]:
             runtime = runtime.replace(tzinfo=timezone.utc)
@@ -274,12 +276,10 @@ async def handler(ctx: dict):
             try:
                 # Tightened up to attempt to prevent service stacking
                 resp = await client.get(url)
-            except Exception as exp:
+            except httpx.RequestError as exp:
                 LOG.warning("URL %s download failed with %s", url, exp)
-                raise HTTPException(
-                    503,
-                    detail="mtarchive backend failed, try later please.",
-                ) from exp
+                last_request_error = exp
+                continue
             if resp.status_code == 200:
                 sz = sio.write(resp.text)
                 row = LOCS[(LOCS["model"] == model) & (LOCS["sid"] == station)]
@@ -289,6 +289,10 @@ async def handler(ctx: dict):
                 lon = float(row["lon"])
                 break
     if sz == 0:
+        if last_request_error is not None:
+            raise HTTPException(
+                503, detail="mtarchive backend failed, try later please."
+            ) from last_request_error
         raise HTTPException(422, detail="Could not find any profile.")
     if ctx["fmt"] == "txt":
         return sio.getvalue()
@@ -353,7 +357,13 @@ async def service(
     ),
     time: datetime = Query(None, description="Profile Valid Time in UTC"),
     runtime: datetime = Query(None, description="Model Init Time UTC"),
-    station: str = Query(None, description="bufkit site identifier"),
+    station: Annotated[
+        str | None,
+        Query(
+            description="bufkit site identifier",
+            pattern=r"^[a-zA-Z0-9\#\-]{3,5}$",
+        ),
+    ] = None,
     fall: bool = Query(False, description="Include all forecast hours"),
     gr: bool = Query(False, description="Use Gibson Ridge JSON Schema"),
 ):

--- a/tests/nws/test_bufkit.py
+++ b/tests/nws/test_bufkit.py
@@ -13,11 +13,18 @@ from iemws.services.nws import bufkit
 URLS = re.compile(r"`/api/1([^\s]*)`")
 
 
+def test_station_with_hashtag_id(client: TestClient):
+    """Test that we can deal with a station with a # in the name."""
+    resp = client.get("/nws/bufkit.json?model=GFS&station=A%231")
+    assert resp.status_code == 200
+
+
 def test_error_handling(httpx_mock: HTTPXMock, client: TestClient):
     """Test error handling code paths."""
     # Simulate a timeout
     httpx_mock.add_exception(
-        httpx.TimeoutException("Simulated timeout for testing")
+        httpx.TimeoutException("Simulated timeout for testing"),
+        is_reusable=True,
     )
     res = client.get("/nws/bufkit.json?lon=-92.5&lat=42.5")
     assert res.status_code == 503


### PR DESCRIPTION
Attempt to prevent upstream slowness from over-running API workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The BUFKIT data service is fully async for better concurrency and responsiveness; file parsing is moved off the main loop to avoid blocking.
* **Bug Fixes**
  * Improved retry and error handling for remote downloads; clearer 503/422 responses based on failure type.
* **Tests**
  * Added a test to verify station IDs containing a literal "#" are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->