### PR TITLE
🎨 Update telemetry write to use pyiem syslog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.14"
+    rev: "v0.15.15"
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
 RUN micromamba env create -y -n iemws -f /tmp/environment.yml \
 	&& micromamba clean --all --yes
 
+# Le Sigh, we need pyiem installed from github
+RUN micromamba run -n iemws python -m pip install git+https://github.com/akrherz/pyiem.git --no-deps
+
 COPY --chown=$MAMBA_USER:$MAMBA_USER src ./src
 COPY --chown=$MAMBA_USER:$MAMBA_USER dev.sh ./dev.sh
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ GHCR image with Podman:
    - `/mesonet/data` (mounted read-only into container at same path)
    - `/mnt/mesonet2` (mounted read-only for symlink targets under `/mesonet/data`)
    - `/opt/bufkit` (mounted read-only into container at same path)
+   - host syslog socket (default `/dev/log`) if telemetry is emitted via syslog
 3. Configure publish binding in `iemws.env`:
    - local proxy on same host: `PUBLISH_HOST=127.0.0.1`
    - proxy on remote host: `PUBLISH_HOST=0.0.0.0` or a specific interface IP
@@ -50,6 +51,11 @@ Set `PGPASS_SECRET` in `iemws.env` if you use a different secret name.
 
 Set `PUBLISH_HOST` and `PUBLISH_PORT` in `iemws.env` to control where Podman
 publishes the API port.
+
+Telemetry emitted via `pyiem.webutil.write_telemetry()` should usually go to the
+host rsyslog socket, not directly to the centralized collector. This keeps relay
+policy, buffering, and forwarding centralized on the host. The systemd unit bind
+mounts `SYSLOG_SOCKET` to `/dev/log` inside the container.
 
 1. Install and enable the service:
 

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -10,7 +10,6 @@ DB_IMAGE="${IEMWS_DB_IMAGE:-ghcr.io/akrherz/iem_database:test_data}"
 START_DB="${IEMWS_START_DB:-1}"
 DBHOST="${IEMWS_DBHOST:-127.0.0.1}"
 DBUSER="${IEMWS_DBUSER:-mesonet}"
-DISABLE_TELEMETRY="${IEMWS_DISABLE_TELEMETRY:-1}"
 
 # Build a runnable image with Python dependencies and app code.
 docker build -t "$IMAGE" -f Dockerfile .
@@ -35,14 +34,12 @@ if [ "$START_DB" = "1" ]; then
 		--network "container:$DB_CONTAINER" \
 		-e IEMWS_DBHOST="$DBHOST" \
 		-e IEMWS_DBUSER="$DBUSER" \
-		-e IEMWS_DISABLE_TELEMETRY="$DISABLE_TELEMETRY" \
 		-d "$IMAGE"
 else
 	docker run --name "$CONTAINER" \
 		-p 8000:8000 \
 		-e IEMWS_DBHOST="$DBHOST" \
 		-e IEMWS_DBUSER="$DBUSER" \
-		-e IEMWS_DISABLE_TELEMETRY="$DISABLE_TELEMETRY" \
 		-d "$IMAGE"
 fi
 

--- a/config/systemd/iem-web-services-podman.service
+++ b/config/systemd/iem-web-services-podman.service
@@ -12,6 +12,7 @@ Environment="PGPASS_UID=57439"
 Environment="PGPASS_GID=57439"
 Environment="PUBLISH_HOST=127.0.0.1"
 Environment="PUBLISH_PORT=8000"
+Environment="SYSLOG_SOCKET=/dev/log"
 Environment="WORKERS=6"
 Environment="MAX_REQUESTS=2000"
 EnvironmentFile=-/etc/iem-web-services/iemws.env
@@ -19,7 +20,7 @@ EnvironmentFile=-/etc/iem-web-services/iemws.env
 ExecStartPre=-/usr/bin/podman rm -f ${CONTAINER_NAME}
 ExecStartPre=/usr/bin/podman pull ${IMAGE}
 ExecStartPre=/usr/bin/podman secret inspect ${PGPASS_SECRET}
-ExecStart=/usr/bin/podman run --name ${CONTAINER_NAME} --replace --publish ${PUBLISH_HOST}:${PUBLISH_PORT}:8000 --volume /mesonet/data:/mesonet/data:ro --volume /mnt/mesonet2:/mnt/mesonet2:ro --volume /opt/bufkit:/opt/bufkit:ro --env-file ${ENV_FILE} --env PGPASSFILE=/run/secrets/pgpass --secret ${PGPASS_SECRET},type=mount,target=pgpass,uid=${PGPASS_UID},gid=${PGPASS_GID},mode=0600 --log-driver=journald ${IMAGE} micromamba run -n iemws gunicorn -w ${WORKERS} --graceful-timeout 60 -k iemws.worker.RestartableUvicornWorker -b 0.0.0.0:8000 --max-requests ${MAX_REQUESTS} --max-requests-jitter 500 --log-level warning iemws.main:app
+ExecStart=/usr/bin/podman run --name ${CONTAINER_NAME} --replace --publish ${PUBLISH_HOST}:${PUBLISH_PORT}:8000 --volume /mesonet/data:/mesonet/data:ro --volume /mnt/mesonet2:/mnt/mesonet2:ro --volume /opt/bufkit:/opt/bufkit:ro --volume ${SYSLOG_SOCKET}:/dev/log --env-file ${ENV_FILE} --env PGPASSFILE=/run/secrets/pgpass --secret ${PGPASS_SECRET},type=mount,target=pgpass,uid=${PGPASS_UID},gid=${PGPASS_GID},mode=0600 --log-driver=journald ${IMAGE} micromamba run -n iemws gunicorn -w ${WORKERS} --graceful-timeout 60 -k iemws.worker.RestartableUvicornWorker -b 0.0.0.0:8000 --max-requests ${MAX_REQUESTS} --max-requests-jitter 500 --log-level warning iemws.main:app
 ExecStop=/usr/bin/podman stop -t 30 ${CONTAINER_NAME}
 ExecStopPost=-/usr/bin/podman rm -f ${CONTAINER_NAME}
 

--- a/config/systemd/iemws.env.example
+++ b/config/systemd/iemws.env.example
@@ -13,6 +13,10 @@ PGPASS_GID=57439
 PUBLISH_HOST=127.0.0.1
 PUBLISH_PORT=8000
 
+# Host syslog socket to mount into container for telemetry routing.
+# Override if your host uses a different socket path.
+SYSLOG_SOCKET=/dev/log
+
 # Database connectivity
 # Use per-database host settings for sharded deployments.
 # Examples:
@@ -23,9 +27,6 @@ PUBLISH_PORT=8000
 #
 # Global fallback user can still be set if desired.
 IEMWS_DBUSER=mesonet
-
-# Set to 1 to disable telemetry writes.
-IEMWS_DISABLE_TELEMETRY=0
 
 # Container runtime tuning (optional)
 WORKERS=6

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,8 @@ dependencies:
   - codecov
   - fastapi
   - geopandas
+  # lame need for docker build
+  - git
   - gunicorn
   - httpx
   - metpy

--- a/src/iemws/main.py
+++ b/src/iemws/main.py
@@ -150,17 +150,20 @@ def _write_telemetry_from_request(
         path = f"/api/1{path}"
     # The best that we can do.
     host = request.headers.get("x-forwarded-server", "").split(",")[0].strip()
-    write_telemetry(
-        TELEMETRY(
-            response_time,
-            status_code,
-            "127.0.0.1" if remote_addr == "testclient" else remote_addr,
-            f"{path}",
-            f"{path}?{request.url.query}",
-            host,
-            utc().strftime(ISO8601),
+    try:
+        write_telemetry(
+            TELEMETRY(
+                response_time,
+                status_code,
+                "127.0.0.1" if remote_addr == "testclient" else remote_addr,
+                f"{path}",
+                f"{path}?{request.url.query}",
+                host,
+                utc().strftime(ISO8601),
+            )
         )
-    )
+    except Exception:
+        LOG.exception("telemetry write failed")
 
 
 @app.middleware("http")

--- a/src/iemws/main.py
+++ b/src/iemws/main.py
@@ -29,19 +29,16 @@ Please don't sue Iowa State University when daryl herzmann gets hit by a bus
 someday and then entire IEM goes away!
 """
 
-import os
-import threading
 import time
 import warnings
-from collections import namedtuple
-from datetime import timedelta
 from logging.config import dictConfig
-from queue import Queue
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from pyiem.database import USERNAME_MAPPER, get_dbconn
+from pyiem.database import USERNAME_MAPPER
+from pyiem.reference import ISO8601
 from pyiem.util import LOG, utc
+from pyiem.webutil import TELEMETRY, write_telemetry
 from shapely.errors import ShapelyDeprecationWarning
 
 from .config import log_config
@@ -127,75 +124,6 @@ tags_metadata = [
 ]
 
 dictConfig(log_config)
-# Queue for writing telemetry data to database
-TELEMETRY_QUEUE = Queue()
-TELEMETRY_QUEUE_THREAD = {"worker": None, "dbconn": None, "lasterr": utc(1980)}
-TELEMETRY_ENABLED = os.getenv("IEMWS_DISABLE_TELEMETRY", "0").lower() not in (
-    "1",
-    "true",
-    "yes",
-)
-TELEMETRY = namedtuple(
-    "TELEMETRY",
-    ["timing", "status_code", "client_addr", "app", "request_uri", "vhost"],
-)
-
-
-def _writer(data):
-    """Actually write the data."""
-    if TELEMETRY_QUEUE_THREAD["dbconn"] is None:
-        # If not set, will default to hostname iemdb-mesosite.local
-        host = os.getenv("IEMWS_DBHOST_MESOSITE")
-        user = os.getenv("IEMWS_DBUSER")
-        db_kwargs = {"rw": True}
-        if host:
-            db_kwargs["host"] = host
-        if user:
-            db_kwargs["user"] = user
-        TELEMETRY_QUEUE_THREAD["dbconn"] = get_dbconn("mesosite", **db_kwargs)
-    cursor = TELEMETRY_QUEUE_THREAD["dbconn"].cursor()
-    cursor.execute(
-        """
-        insert into website_telemetry(timing, status_code, client_addr,
-        app, request_uri, vhost) values (%s, %s, %s, %s, %s, %s)
-        """,
-        (
-            data.timing,
-            data.status_code,
-            data.client_addr,
-            data.app,
-            data.request_uri,
-            data.vhost,
-        ),
-    )
-    cursor.close()
-    TELEMETRY_QUEUE_THREAD["dbconn"].commit()
-
-
-def _writer_thread():
-    """Runs for ever and writes telemetry data to the database."""
-    while True:
-        data = TELEMETRY_QUEUE.get()
-
-        try:
-            if utc() > TELEMETRY_QUEUE_THREAD["lasterr"]:
-                _writer(data)
-        except Exception as exp:
-            TELEMETRY_QUEUE_THREAD["lasterr"] = utc() + timedelta(minutes=5)
-            LOG.exception(exp)
-            TELEMETRY_QUEUE_THREAD["dbconn"] = None
-
-
-def _add_to_queue(data):
-    """Adds data to queue, ensures a thread is running to process."""
-    if TELEMETRY_QUEUE_THREAD["worker"] is None:
-        TELEMETRY_QUEUE_THREAD["worker"] = threading.Thread(
-            target=_writer_thread,
-            name="telemetry",
-            daemon=True,
-        )
-        TELEMETRY_QUEUE_THREAD["worker"].start()
-    TELEMETRY_QUEUE.put(data)
 
 
 app = FastAPI(
@@ -206,12 +134,10 @@ app = FastAPI(
 )
 
 
-def _add_to_queue_from_request(
+def _write_telemetry_from_request(
     request: Request, response_time: float, status_code: int
 ):
     """Add telemetry data from request."""
-    if not TELEMETRY_ENABLED:
-        return
     # within pytest, request.client is None
     clienthost = None if request.client is None else request.client.host
     remote_addr = (
@@ -224,7 +150,7 @@ def _add_to_queue_from_request(
         path = f"/api/1{path}"
     # The best that we can do.
     host = request.headers.get("x-forwarded-server", "").split(",")[0].strip()
-    _add_to_queue(
+    write_telemetry(
         TELEMETRY(
             response_time,
             status_code,
@@ -232,6 +158,7 @@ def _add_to_queue_from_request(
             f"{path}",
             f"{path}?{request.url.query}",
             host,
+            utc().strftime(ISO8601),
         )
     )
 
@@ -246,7 +173,7 @@ async def record_request_timing(request: Request, call_next):
     if response.status_code not in [
         405,
     ]:
-        _add_to_queue_from_request(
+        _write_telemetry_from_request(
             request, time.time() - start_time, response.status_code
         )
 
@@ -256,7 +183,7 @@ async def record_request_timing(request: Request, call_next):
 def handle_exception(request: Request, exc):
     """Handle exceptions."""
     LOG.exception("Exception for %s", request.url, exc_info=exc)
-    _add_to_queue_from_request(request, 0, 500)
+    _write_telemetry_from_request(request, 0, 500)
     return JSONResponse(
         status_code=500,
         content="Unexpected error, email akrherz@iastate.edu if you wish :)",


### PR DESCRIPTION
This avoids a complicated direct database write of telemetry as IEM now handles this via syslog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated deployment documentation with syslog socket prerequisites and telemetry routing guidance.

* **Configuration**
  * Telemetry routing now uses the host syslog socket.
  * Removed `IEMWS_DISABLE_TELEMETRY` environment variable; telemetry is always enabled.
  * Added `SYSLOG_SOCKET` configuration option for systemd deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akrherz/iem-web-services/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->